### PR TITLE
use data prefix prop instead of defaultIndex on header node

### DIFF
--- a/src/components/nav/nav.js
+++ b/src/components/nav/nav.js
@@ -25,7 +25,7 @@ export default class Tab extends React.Component {
     };
 
     render() {
-        const {children, className, type, ...others} = this.props;
+        const {children, className, type, defaultIndex} = this.props;
         const cls = classNames({
             bar: true,
             bar_nav: true
@@ -34,7 +34,7 @@ export default class Tab extends React.Component {
         switch(type){
             case 'button':
                 return (
-                    <header className={cls} {...others}>
+                    <header className={cls} data-index={defaultIndex}>
                         {children}
                     </header>
                 );
@@ -45,7 +45,7 @@ export default class Tab extends React.Component {
                 break;
             default:
                 return (
-                    <header className={cls} {...others}>
+                    <header className={cls} data-index={defaultIndex}}>
                         {children}
                     </header>
                 );


### PR DESCRIPTION
使用`Nav`组件时，出现如下警告

``` sh
warning.js?85a7:44Warning: Unknown prop `defaultIndex` on <header> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in header (created by Tab)
    in Tab (created by ItemSupplies)
    in div (created by ItemSupplies)
    in ItemSupplies (created by Connect(ItemSupplies))
    in Connect(ItemSupplies) (created by RouterContext)
    in div (created by Mobile)
    in Mobile (created by RouterContext)
    in Provider (created by Main)
    in Main (created by RouterContext)
    in RouterContext (created by Router)
    in Router
```

警告原因是在`header`标签上使用`defaultIndex`属性，更好的做法是在原生标签上使用`data-`前缀来添加自定义属性。

> https://facebook.github.io/react/warnings/unknown-prop.html
> https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Using_data_attributes
